### PR TITLE
fix(readme): Add missing `use` to example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ win_event_hook = "0.1"
 Then create a configuration and install a hook, for example:
 
 ```rust
+use win_event_hook::events::{Event, NamedEvent};
+
 // create our hook config
 let config = win_event_hook::Config::builder()
     .skip_own_process()


### PR DESCRIPTION
Update the example code so that `Event` and `NamedEvent` are in scope.