### PR TITLE
feat(0.3.0): Bump `windows` version, small fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,3 @@
 [workspace]
-members = [
-    "crates/*"
-]
+resolver = "2"
+members = ["crates/*"]

--- a/crates/win_event_hook/Cargo.toml
+++ b/crates/win_event_hook/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "win_event_hook"
 publish = true
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 authors = ["Ben <ben+crates@bengreenier.com>"]
 description = "A safe rust API for using SetWinEventHook, powered by the windows crate"
@@ -26,7 +26,7 @@ tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 
 [target.'cfg(windows)'.dependencies.windows]
-version = "0.48.0"
+version = "0.51.1"
 features = [
     # SetWinEventHook
     "Win32_Foundation",
@@ -34,5 +34,5 @@ features = [
     # Event constants
     "Win32_UI_WindowsAndMessaging",
     # GetCurrentThreadId
-    "Win32_System_Threading"
+    "Win32_System_Threading",
 ]

--- a/crates/win_event_hook/src/hook.rs
+++ b/crates/win_event_hook/src/hook.rs
@@ -184,7 +184,7 @@ impl WinEventHookInner for ThreadedInner {
         if self.installed() {
             // stop the event loop
             unsafe { PostThreadMessageW(self.thread_pool_tid, WM_QUIT, WPARAM(0), LPARAM(0)) }
-                .ok()?;
+                .map_err(|_| Error::Uninstallation)?;
 
             // uninstall the event hook, and return the result
             self.thread_pool.install(|| self.unthreaded.uninstall())


### PR DESCRIPTION
- Bumps `windows` to `0.51.1`
- Specifies workspace `resolver` as "2"
- Handles new `PostThreadMessageW` failure