### PR TITLE
feat(v0.4.0): Update handle usage, support unknown events

### DIFF
--- a/crates/win_event_hook/Cargo.toml
+++ b/crates/win_event_hook/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "win_event_hook"
 publish = true
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 authors = ["Ben <ben+crates@bengreenier.com>"]
 description = "A safe rust API for using SetWinEventHook, powered by the windows crate"
@@ -16,17 +16,18 @@ categories = ["api-bindings", "os", "os::windows-apis"]
 targets = ["x86_64-pc-windows-msvc"]
 
 [dependencies]
-bitflags = "2.3.3"
-lazy_static = "1.4.0"
-rayon = "1.7.0"
-thiserror = "1.0.40"
-tracing = "0.1.37"
+bitflags = "2.3"
+lazy_static = "1.4"
+rayon = "1.7"
+thiserror = "1.0"
+tracing = "0.1"
 
 [dev-dependencies]
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
+tracing-test = "0.2"
 
 [target.'cfg(windows)'.dependencies.windows]
-version = "0.51.1"
+version = "0.58"
 features = [
     # SetWinEventHook
     "Win32_Foundation",

--- a/crates/win_event_hook/src/config.rs
+++ b/crates/win_event_hook/src/config.rs
@@ -1,10 +1,6 @@
-use windows::Win32::Foundation::HMODULE;
-
 use crate::events::Event;
 use crate::flags::Flags;
-
-/// Re-exported [`windows::Win32::Foundation::HMODULE`].
-pub type ModuleHandle = HMODULE;
+use crate::handles::ModuleHandle;
 
 /// Config for
 /// [SetWinEventHook](https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-setwineventhook).
@@ -95,7 +91,7 @@ impl ConfigBuilder {
             event_max = id;
         }
 
-        let mut event_filter = self.inner.event_filter.unwrap_or(Vec::new());
+        let mut event_filter = self.inner.event_filter.unwrap_or_default();
 
         event_filter.push(event);
 
@@ -115,7 +111,7 @@ impl ConfigBuilder {
     pub fn with_events<T: Into<Vec<Event>>>(self, events: T) -> Self {
         let mut event_min = self.inner.event_min;
         let mut event_max = self.inner.event_max;
-        let mut event_filter = self.inner.event_filter.unwrap_or(Vec::new());
+        let mut event_filter = self.inner.event_filter.unwrap_or_default();
 
         for event in events.into() {
             let id: u32 = event.into();

--- a/crates/win_event_hook/src/event_loop.rs
+++ b/crates/win_event_hook/src/event_loop.rs
@@ -8,7 +8,7 @@ use windows::Win32::{
 pub unsafe fn run_event_loop() {
     trace!("starting event_loop");
     let mut message = MSG::default();
-    while GetMessageW(&mut message, HWND(0), 0, 0).into() {
+    while GetMessageW(&mut message, HWND(std::ptr::null_mut()), 0, 0).into() {
         if message.message == WM_QUIT {
             break;
         }

--- a/crates/win_event_hook/src/events.rs
+++ b/crates/win_event_hook/src/events.rs
@@ -34,6 +34,7 @@ pub enum Event {
     Oem(OemEvent),
     Uia(UiaEvent),
     UiaProperty(UiaPropertyEvent),
+    Unknown(u32),
 }
 
 impl Event {
@@ -82,6 +83,7 @@ impl From<Event> for u32 {
             Event::Oem(inner) => inner.into(),
             Event::Uia(inner) => inner.into(),
             Event::UiaProperty(inner) => inner.into(),
+            Event::Unknown(value) => value,
         }
     }
 }
@@ -94,31 +96,30 @@ impl From<&Event> for u32 {
             Event::Oem(inner) => inner.into(),
             Event::Uia(inner) => inner.into(),
             Event::UiaProperty(inner) => inner.into(),
+            Event::Unknown(value) => *value,
         }
     }
 }
 
-impl TryFrom<u32> for Event {
-    type Error = crate::errors::Error;
-
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
+impl From<u32> for Event {
+    fn from(value: u32) -> Self {
         if let Ok(event) = UiaPropertyEvent::try_from(value) {
-            return Ok(Event::UiaProperty(event));
+            return Event::UiaProperty(event);
         }
         if let Ok(event) = UiaEvent::try_from(value) {
-            return Ok(Event::Uia(event));
+            return Event::Uia(event);
         }
         if let Ok(event) = OemEvent::try_from(value) {
-            return Ok(Event::Oem(event));
+            return Event::Oem(event);
         }
         if let Ok(event) = AiaEvent::try_from(value) {
-            return Ok(Event::Aia(event));
+            return Event::Aia(event);
         }
         if let Ok(event) = NamedEvent::try_from(value) {
-            return Ok(Event::Named(event));
+            return Event::Named(event);
         }
 
-        Err(crate::errors::Error::InvalidEvent(value))
+        Event::Unknown(value)
     }
 }
 

--- a/crates/win_event_hook/src/handler.rs
+++ b/crates/win_event_hook/src/handler.rs
@@ -1,9 +1,4 @@
-use windows::Win32::Foundation::HWND;
-
-use crate::events::Event;
-
-/// Re-exported [`windows::Win32::Foundation::HWND`].
-pub type WindowHandle = HWND;
+use crate::{events::Event, handles::WindowHandle};
 
 /// Signature of the Event Hook callback function.
 pub trait EventHandler: Fn(Event, WindowHandle, i32, i32, u32, u32) + Sync + Send {}

--- a/crates/win_event_hook/src/handles.rs
+++ b/crates/win_event_hook/src/handles.rs
@@ -1,0 +1,146 @@
+use std::fmt::Debug;
+use std::hash::{Hash, Hasher};
+use std::ops::{Deref, DerefMut};
+
+/// Built-in [`PlatformHandle`] implementations for commonly used windows handle types.
+pub mod builtins {
+    use std::{ffi::c_void, hash::Hash};
+
+    use windows::Win32::{
+        Foundation::{HMODULE, HWND},
+        UI::Accessibility::HWINEVENTHOOK,
+    };
+
+    use super::PlatformHandle;
+
+    /// Re-exported [`HWINEVENTHOOK`].
+    pub type OsHandle = HWINEVENTHOOK;
+
+    impl PlatformHandle for OsHandle {
+        type Primitive = *mut c_void;
+
+        fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+            // Cast the reference to a raw pointer and hash the address
+            let ptr = self.0 as *const c_void as usize;
+
+            ptr.hash(state);
+        }
+    }
+
+    /// Re-exported [`windows::Win32::Foundation::HMODULE`].
+    pub type ModuleHandle = HMODULE;
+
+    impl PlatformHandle for ModuleHandle {
+        type Primitive = *mut c_void;
+
+        fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+            // Cast the reference to a raw pointer and hash the address
+            let ptr = self.0 as *const c_void as usize;
+
+            ptr.hash(state);
+        }
+    }
+
+    /// Re-exported [`windows::Win32::Foundation::HWND`].
+    pub type WindowHandle = HWND;
+
+    impl PlatformHandle for WindowHandle {
+        type Primitive = *mut c_void;
+
+        fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+            // Cast the reference to a raw pointer and hash the address
+            let ptr = self.0 as *const c_void as usize;
+
+            ptr.hash(state);
+        }
+    }
+}
+
+/// A [`Handle`] containing `HWINEVENTHOOK` under-the-hood.
+pub type OsHandle = OpaqueHandle<builtins::OsHandle>;
+
+/// A [`Handle`] containing `HMODULE` under-the-hood.
+pub type ModuleHandle = OpaqueHandle<builtins::ModuleHandle>;
+
+/// A [`Handle`] containing `HWND` under-the-hood.
+pub type WindowHandle = OpaqueHandle<builtins::WindowHandle>;
+
+/// Abstraction for platform handles (see `builtins`) that constrain them to align with our requirements.
+pub trait PlatformHandle: Debug + Clone + PartialEq + Eq {
+    /// The type of the handles underlying value. For instance, `isize` or `*mut c_void`.
+    type Primitive: Debug + Clone + PartialEq + Eq;
+
+    // TODO(bengreenier): not sure why contstraining to `Hash` doesn't work, but it doesn't.
+    fn hash<H: Hasher>(&self, state: &mut H);
+}
+
+/// Abstraction for application handles used throughout this library.
+///
+/// See [`OpaqueHandle`].
+pub trait Handle: Debug + Clone + PartialEq + Eq + Hash {
+    type PlatformHandle: PlatformHandle;
+}
+
+/// Abstraction for application handles that allow them to meet our safety requirements.
+///
+/// This is what we store within the `win_event_hook` library, and callers may store within
+/// their application.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OpaqueHandle<T: PlatformHandle>(T);
+
+impl<T> Handle for OpaqueHandle<T>
+where
+    T: PlatformHandle,
+{
+    type PlatformHandle = T;
+}
+
+unsafe impl<T> Sync for OpaqueHandle<T> where T: PlatformHandle {}
+unsafe impl<T> Send for OpaqueHandle<T> where T: PlatformHandle {}
+
+impl<T> From<T> for OpaqueHandle<T>
+where
+    T: PlatformHandle,
+{
+    fn from(value: T) -> Self {
+        Self(value)
+    }
+}
+
+impl<T> Deref for OpaqueHandle<T>
+where
+    T: PlatformHandle,
+{
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<T> DerefMut for OpaqueHandle<T>
+where
+    T: PlatformHandle,
+{
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl<T> Hash for OpaqueHandle<T>
+where
+    T: PlatformHandle,
+{
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.0.hash(state);
+    }
+}
+
+impl<T> Default for OpaqueHandle<T>
+where
+    T: PlatformHandle + Default,
+{
+    fn default() -> Self {
+        Self(T::default())
+    }
+}

--- a/crates/win_event_hook/src/lib.rs
+++ b/crates/win_event_hook/src/lib.rs
@@ -3,9 +3,9 @@ use std::{fmt::Debug, hash::Hash};
 pub use config::Config;
 use errors::{Error, Result};
 pub use handler::EventHandler;
+use handles::Handle;
 use hook::{ThreadedInner, UnthreadedInner, WinEventHookInner};
 use tracing::trace;
-use windows::Win32::UI::Accessibility::HWINEVENTHOOK;
 
 pub mod config;
 pub mod errors;
@@ -13,10 +13,8 @@ mod event_loop;
 pub mod events;
 pub mod flags;
 pub mod handler;
+pub mod handles;
 mod hook;
-
-/// Re-exported [`HWINEVENTHOOK`].
-pub type OsHandle = HWINEVENTHOOK;
 
 /// A Windows Event Hook, managed using the
 /// [SetWinEventHook](https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-setwineventhook)
@@ -29,7 +27,7 @@ pub struct WinEventHook {
 
 impl WinEventHook {
     /// Obtains a reference to the os-specific handle of the event hook.
-    pub fn os_handle(&self) -> &Option<OsHandle> {
+    pub fn os_handle(&self) -> &Option<impl Handle> {
         self.inner.handle()
     }
 
@@ -82,9 +80,7 @@ impl Eq for WinEventHook {}
 
 impl Hash for WinEventHook {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        let maybe_os_handle = self.os_handle().and_then(|handle| Some(handle.0));
-
-        maybe_os_handle.hash(state)
+        self.os_handle().hash(state)
     }
 }
 


### PR DESCRIPTION
- This adds support for `Event::Unknown(u32)` when we don't recognize an event constant.
- This refactors handles (see `handles` module) so we can hopefully modify less logic when `windows` updates.